### PR TITLE
Adding GPU Support for Mac M1

### DIFF
--- a/arguments.py
+++ b/arguments.py
@@ -44,8 +44,18 @@ class ArgumentsBase(object):
 
         # set gpu ids
         if len(self.opt.gpu_ids) > 0:
-            torch.cuda.set_device(self.opt.gpu_ids[0])
+            # torch.cuda.set_device(self.opt.gpu_ids[0])
+            # Check for device compatibility and set it
+            if torch.cuda.is_available():
+                device = torch.device(f"cuda:{self.opt.gpu_ids[0]}")
+            elif torch.backends.mps.is_available() and torch.backends.mps.is_built():
+                device = torch.device("mps")
+            else:
+                device = torch.device("cpu")
 
+            # Set the device for PyTorch
+            self.opt.device = device
+            print(f"Using device: {device}")
         return self.opt
 
 


### PR DESCRIPTION
This PR introduces modifications to enable GPU support on Mac M1 chips using Metal Performance Shaders (MPS) via torch.device("mps"). The following are the main changes:

Changes:
Automatic GPU Configuration: This update allows automatic selection of the MPS device if available, enabling GPU acceleration on M1 chips. Expanded torch.device Support: It removes the dependency on torch.cuda and selects the appropriate device depending on the availability of MPS. Compatibility: The code has been tested to ensure smooth operation in non-M1 environments and where MPS is unsupported. Purpose:
This PR aims to provide fast GPU support for PyTorch users on Mac M1, improving performance, especially for deep learning inference and training tasks.

Testing and Verification:
Confirmed functionality on M1 environment.
Ensured compatibility with non-MPS and traditional CUDA environments. Merging this PR will enhance the development experience for M1 users, increasing processing speed for computationally intensive models.


-----

Mac M1でのGPUサポート追加

このPRは、MacのM1チップ上でtorch.device("mps")を使用してMetal Performance Shaders（MPS）によるGPUサポートを有効にするための変更を加えています。以下は主な変更点です。

変更内容：
GPU設定の自動判別：M1チップが利用可能な場合、MPSデバイスを自動的に選択するようにし、GPU処理を活用します。
torch.deviceの対応強化：従来のtorch.cuda依存をなくし、MPSデバイスの有無に応じて適切なデバイスを選択できるようにしました。
互換性の保持：非M1環境やMPS非対応の環境でも問題なく動作するように考慮しています。
目的：
Mac M1ユーザーに対して、PyTorchによる高速なGPU処理のサポートを提供することで、特にディープラーニングの推論やトレーニングでのパフォーマンス向上を目指します。

テストと確認：
M1環境での動作確認済み
非MPS環境や従来のCUDA環境でも正常に動作することを確認済みです。
このPRがマージされることで、M1ユーザーにとっての開発体験が向上し、高い計算負荷のあるモデルにおける処理速度向上が期待されます。
